### PR TITLE
Add docker-compose for deployment, build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 metals.sbt
 fofsequa.conf
 lib/
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # Nanquanu Speed Dating Web Frontend
-Source code of the application can be found in ./nq\_speed\_dating\_web\_frontend
+
+Source code of the application can be found in ./nq_speed_dating_web_frontend
+
+## Docker
+
+To use the `docker-compose.yaml`, make sure you build the scala app docker image first.
+You can achieve this by executing `sbt docker:publishLocal`.
+
+Then simply execute `docker-compose up -d` to run it locally, or add `--context` with your context to deploy remotely.
+
+//TODO automate building of docker image in a pipeline (github actions)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: "3"
+services:
+  speeddating_app:
+    image: nq_speed_dating_web_frontend:0.1-SNAPSHOT
+    ports:
+      - 3000:8080
+    depends_on:
+      - speeddating_db
+  speeddating_db:
+    image: "postgres"
+    env_file:
+      - .env
+    volumes:
+      - speeddating_db-data:/var/lib/postgresql/data/
+volumes:
+  speeddating_db-data:


### PR DESCRIPTION
This PR will add a docker-compose.yaml, to launch multiple docker containers to form a service. This can be used for easy deployment. Currently it launches the scala application and a postgres container.

+ Add docker-compose ✅ 
+ Update README 📖  